### PR TITLE
FEATURE: auto create a staff note when an official warning is created

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,3 +2,6 @@ en:
   site_settings:
     staff_notes_enabled: "Allow staff users to attach notes to users"
     staff_notes_moderators_delete: "Allow moderators to delete staff notes"
+
+  staff_notes:
+    official_warning: "Received an official warning from @%{username} -- %{warning_link}"

--- a/plugin.rb
+++ b/plugin.rb
@@ -151,4 +151,12 @@ after_initialize do
     mount ::DiscourseStaffNotes::Engine, at: "/staff_notes"
   end
 
+  add_model_callback :warning, :after_create do
+    user = User.find_by_id(self.user_id)
+    created_by_user = User.find_by_id(self.created_by_id)
+    warning_topic = Topic.find_by_id(self.topic_id)
+    raw_note = I18n.t("staff_notes.official_warning", username: created_by_user.username, warning_link: "[#{warning_topic.title}](#{warning_topic.url})")
+    ::DiscourseStaffNotes.add_note(user, raw_note, Discourse::SYSTEM_USER_ID)
+  end
+
 end


### PR DESCRIPTION
When an official warning is created, create a staff note (from system) automatically with a link to that warning topic.

<img width="742" alt="screen shot 2016-04-04 at 19 01 40" src="https://cloud.githubusercontent.com/assets/5732281/14249535/cf7b7dcc-fa97-11e5-8393-3a4a1b5b7542.png">

